### PR TITLE
Add border radius to background markers

### DIFF
--- a/styles/pigments.less
+++ b/styles/pigments.less
@@ -80,6 +80,10 @@ pigments-color-marker {
     position: absolute;
     white-space: pre;
 
+    &.background {
+      border-radius: 2px;
+    }
+
     &.outline {
       background-image: url(atom://pigments/resources/transparent-background.png);
       margin-left: -2px;


### PR DESCRIPTION
I missed the subtle refinement of the rounded corners from atom-color-highlight, so this adds a border radius to background markers so the corners aren't sharp.

Before:
![screenshot 2015-05-30 22 55 42](https://cloud.githubusercontent.com/assets/823545/7900345/0440ab76-071f-11e5-8ede-128b396b3d27.png)

After: 
![screenshot 2015-05-30 22 54 30](https://cloud.githubusercontent.com/assets/823545/7900343/e41a7264-071e-11e5-8f36-a94c2002f099.png)
