### PR TITLE
Add vendor (Ruby), spec and test (because typically those are tests.)

### DIFF
--- a/lib/pigments.coffee
+++ b/lib/pigments.coffee
@@ -22,7 +22,10 @@ module.exports =
     ignoredNames:
       type: 'array'
       default: [
-        "node_modules/*"
+        "vendor/*",
+        "node_modules/*",
+        "spec/*",
+        "test/*"
       ]
       description: "Glob patterns of files to ignore when scanning the project for variables."
       items:


### PR DESCRIPTION
These add vendor/*, test/* and spec/* to the list of default ignores beacuse they can be rather large folders that cause pigments to trip out because tests can grow quite large and vendor typically holds vendored dependencies in Ruby.