### PR TITLE
fix #61

### DIFF
--- a/lib/color-expressions.coffee
+++ b/lib/color-expressions.coffee
@@ -9,6 +9,7 @@ cssColor = require 'css-color-function'
   floatOrPercent
   comma
   notQuote
+  notQuoteOrPe
   hexadecimal
   ps
   pe
@@ -66,7 +67,7 @@ blendMethod = (registry, name, method) ->
       (
         #{notQuote}
         #{comma}
-        #{notQuote}
+        #{notQuoteOrPe}
       )
     #{pe}
   "), (match, expression, context) ->

--- a/lib/regexes.coffee
+++ b/lib/regexes.coffee
@@ -14,6 +14,7 @@ module.exports =
   floatOrPercent: "(#{percent}|#{float})"
   comma: '\\s*,\\s*'
   notQuote: "[^\"'\\n]+"
+  notQuoteOrPe: "[^\"'\\n\)]+"
   hexadecimal: '[\\da-fA-F]'
   ps: '\\(\\s*'
   pe: '\\s*\\)'


### PR DESCRIPTION
adding something like this to the spec would prevent regressions, but it would simply crash the specs when the :beetle: reoccurs.
```coffeescript
  itParses('difference(a,b))').asColor('#990066')
```