### PR TITLE
Fixes styling errors on Seti-UI

### DIFF
--- a/lib/palette-element.coffee
+++ b/lib/palette-element.coffee
@@ -17,7 +17,7 @@ class PaletteElement extends HTMLElement
       attrs
 
     @div class: 'pigments-palette-panel', =>
-      @div class: 'pigments-palette-controls settings-view', =>
+      @div class: 'pigments-palette-controls settings-view pane-item', =>
         @div class: 'pigments-palette-controls-wrapper', =>
           @span class: 'input-group-inline', =>
             @label for: 'sort-palette-colors', 'Sort Colors'


### PR DESCRIPTION
Prior to this patch, the settings bar on the pallet bar would be unstyled (white) on Seti-UI, and I would assume other themes, as well.

This just adds the `pane-item` class allowing it to draw styles from the theme's generic pane. This is the same style that the config menu and status bar use.

A quick before and after:
![1](https://cloud.githubusercontent.com/assets/1841149/9362361/d7c1d4ec-4654-11e5-977f-8a6c577dc492.PNG)
![2](https://cloud.githubusercontent.com/assets/1841149/9362364/d950a4d2-4654-11e5-9367-cdf0b1e155eb.PNG)