### PR TITLE
:bug: Fix #264

### DIFF
--- a/lib/color-buffer-element.coffee
+++ b/lib/color-buffer-element.coffee
@@ -300,7 +300,7 @@ class ColorBufferElement extends HTMLElement
         if Array.isArray changes
           changes?.forEach (change) =>
             @updateDotDecorationsOffsets(change.start.row, change.newExtent.row)
-        else
+        else if changes.start? and changes.newExtent?
           @updateDotDecorationsOffsets(changes.start.row, changes.newExtent.row)
 
     @updateGutterDecorations(type)


### PR DESCRIPTION
Fix the issue where an error would be thrown when no changes where made to the editor when using the `dot` marker-type.