### PR TITLE
Fall back to snapshot cache when unable to shim modules in require.cache

### DIFF
--- a/lib/pigments.coffee
+++ b/lib/pigments.coffee
@@ -291,8 +291,23 @@ module.exports =
     .replace(///#{atom.project.getPaths().join('|')}///g, '<root>')
 
   patchAtom: ->
+    getModuleFromNodeCache = (name) ->
+      modulePath = Object.keys(require.cache).filter((s) -> s.indexOf(name) > -1)[0]
+      require.cache[modulePath]
+
+    getModuleFromSnapshotCache = (name) ->
+      if typeof snapshotResult is 'undefined'
+        null
+      else
+        modulePath = Object.keys(snapshotResult.customRequire.cache).filter((s) -> s.indexOf(name) > -1)[0]
+        snapshotResult.customRequire.cache[modulePath]
+
     requireCore = (name) ->
-      require Object.keys(require.cache).filter((s) -> s.indexOf(name) > -1)[0]
+      module = getModuleFromNodeCache(name) ? getModuleFromSnapshotCache(name)
+      if module?
+        module.exports
+      else
+        throw new Error("Cannot find '#{name}' in the require cache.")
 
     HighlightComponent = requireCore('highlights-component')
     TextEditorPresenter = requireCore('text-editor-presenter')


### PR DESCRIPTION
This pull request will solve an issue that @ben3eee caught while testing https://github.com/atom/atom/pull/13916. Specifically, this package is monkey-patching some core modules that won't be available anymore in the `require.cache` when a V8 snapshot is used.

Therefore, after these changes, pigments will try to load modules from `require.cache` first and, if no module can be found there, fall back to `snapshotResult.require.cache`.

/cc: @abe33 