### PR TITLE
:bug: Fix marker background attachment

### DIFF
--- a/styles/pigments.less
+++ b/styles/pigments.less
@@ -24,7 +24,6 @@
 
 .background-color {
   box-sizing: border-box;
-  background-attachment: fixed;
 }
 
 .icon-pigments::before {


### PR DESCRIPTION
Make sure color markers are always visible.
Tested on Windows installation.
Fixes: #348