### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto
+
+/docs export-ignore
+/spec export-ignore
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/changelog.cson export-ignore
+/coffelint.json export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore
+/README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,4 @@
 /.travis.yml export-ignore
 /changelog.cson export-ignore
 /coffelint.json export-ignore
-/CHANGELOG.md export-ignore
 /CONTRIBUTING.md export-ignore
-/README.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 
 /docs export-ignore
 /spec export-ignore
-/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, tests, .travis.yml, etc).

Happy Hacktoberfest!