### PR TITLE
Fix default ignored globs for variable scanning

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,10 +79,13 @@
     "ignoredNames": {
       "type": "array",
       "default": [
-        "vendor/*",
-        "node_modules/*",
-        "spec/*",
-        "test/*"
+        "**/vendor",
+        "**/node_modules",
+        "**/spec",
+        "**/test",
+        "**/font",
+        "**/img",
+        "**/icon"
       ],
       "description": "Glob patterns of files to ignore when scanning the project for variables.",
       "items": {


### PR DESCRIPTION
I noticed that the autocomplete for color variables was showing me colors that I didn't create and I happened to know belong to a certain vendor project, which should not have been picked up by Pigments since the ignored file glob setting for this included `vendor/*` by default.

After a bit of playing with that setting, realized that it needs "absolute" globs to work properly (relative to project root, I guess?). So `vendor/*` changed to `**/vendor` did the trick for me without ignoring my actual color variables.

For this PR, I made that change to the default glob parameters in the `package.json`. To potentially reduce resource usage for others, I also added a few extra globs matching locations commonly found in a website folder structure that clearly wouldn't be of interest to search (e.g. `**/font`, `**/img`, and the like).
